### PR TITLE
Issue on [ID] pages for Centers without Secondary Position

### DIFF
--- a/lib/ratings.js
+++ b/lib/ratings.js
@@ -849,7 +849,10 @@ export const ratePlayer = (playerObj, duoOn, evoLevel, duo, evos) => {
         position,
         secondary_position
     } = info;
-    const positions = [position, secondary_position];
+    const positions = [ position ];
+    if (secondary_position) {
+      positions.push(secondary_position);
+    }
     if (positions.some(pos => pos.indexOf('C') > -1)) {
         positions.push('SC');
     }

--- a/pages/player/[name]/[id].js
+++ b/pages/player/[name]/[id].js
@@ -127,9 +127,9 @@ export default function Player({ playerData, altPlayers, evos, duo, duoPartner, 
                         <div className="column is-three-fifths-desktop pl-0 pt-0 ml-0"><strong>True Ratings</strong> are based on a weighted calculation that favors specific attributes for specific positions, helping measure the true quality of the card. Currently, badging, animations, and player models aren’t factored in. </div>
                         <div className="mb-3 is-size-7 pl-0 ml-0">created by <strong><a href="https://2kgamer.com/u/element">element</a></strong> | implemented by <strong><a href="https://2kgamer.com/u/jdealla">jdealla</a></strong></div>
                     </div>
-                    {trueRatings ? trueRatings.map( ({ overall, sections, position }) => {
+                    {trueRatings ? trueRatings.map( ({ overall, sections, position }, index) => {
                         return (
-                            <div className="column is-one-fifth-desktop is-one-fourth-tablet is-half-mobile">
+                            <div key={`trueRating${index}`} className="column is-one-fifth-desktop is-one-fourth-tablet is-half-mobile">
                                 <Attributes attributes={{overall, ...sections}} attrName={position} trueRating={true}/>
                             </div>
                         );


### PR DESCRIPTION
* Bug fix:`Ratings.js` updated to resolve the issue, to handle cases for centers who only have one position
* Optimization: added key to the parent div for the True Ratings container